### PR TITLE
Ariel/Solve Conflict on CB-6-Create-Account-UI-Layout-Part-Two

### DIFF
--- a/src/components/AuthButton/AuthButton.tsx
+++ b/src/components/AuthButton/AuthButton.tsx
@@ -1,25 +1,14 @@
-import { FC, ReactNode } from 'react'
-import Button, { Variant, Size } from '@/components/Button'
+import { FC } from 'react'
+import Button, { Size, Props as ButtonProps } from '@/components/Button'
 
-type InputProps = {
-  children: ReactNode
-  variant: Variant
+export interface InputProps extends ButtonProps {
   onClick?: () => void
 }
 
-const AuthButton: FC<InputProps> = ({ children, variant, onClick = undefined }) => (
-  <div className="w-full flex items-center justify-center">
-    <Button
-      variant={variant}
-      size={Size.Undefined}
-      type="submit"
-      block
-      className="py-3 font-bold text-base leading-6"
-      onClick={onClick}
-    >
-      {children}
-    </Button>
-  </div>
+const AuthButton: FC<InputProps> = ({ variant, children = '', onClick = undefined }) => (
+  <Button variant={variant} size={Size.Undefined} type="submit" block className="py-3 font-bold" onClick={onClick}>
+    {children}
+  </Button>
 )
 
 export default AuthButton

--- a/src/components/AuthButton/AuthButton.tsx
+++ b/src/components/AuthButton/AuthButton.tsx
@@ -1,0 +1,25 @@
+import { FC, ReactNode } from 'react'
+import Button, { Variant, Size } from '@/components/Button'
+
+type InputProps = {
+  children: ReactNode
+  variant: Variant
+  onClick?: () => void
+}
+
+const AuthButton: FC<InputProps> = ({ children, variant, onClick = undefined }) => (
+  <div className="w-full flex items-center justify-center">
+    <Button
+      variant={variant}
+      size={Size.Undefined}
+      type="submit"
+      block
+      className="py-3 font-bold text-base leading-6"
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  </div>
+)
+
+export default AuthButton

--- a/src/components/AuthButton/index.ts
+++ b/src/components/AuthButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AuthButton'

--- a/src/components/AuthTextField/AuthTextField.tsx
+++ b/src/components/AuthTextField/AuthTextField.tsx
@@ -1,83 +1,37 @@
-import { FC } from 'react'
-import { AiFillEye, AiFillEyeInvisible } from 'react-icons/ai'
+import { FC, ReactNode } from 'react'
 import classNames from 'classnames'
+import TextField, { TextFieldProps } from '@/components/TextFiled'
 
-type RequiredProps = {
-  type: string
-  id: string
-  value: string
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
-  placeholder: string
+export interface AuthTextFieldProps extends TextFieldProps {
+  showIcon?: boolean
+  children?: ReactNode
 }
 
-type OptionalProps = {
-  label: string
-  htmlFor: string
-  togglePasswordVisibility: () => void
-  handleKeyDown: React.KeyboardEventHandler<HTMLInputElement>
-  showPassword: boolean
-  showEyeIcon: boolean
-}
-
-type InputProps = RequiredProps & Partial<OptionalProps>
-
-const AuthTextField: FC<InputProps> = ({
-  label,
-  htmlFor,
+const AuthTextField: FC<AuthTextFieldProps> = ({
   type,
   id,
   value,
   onChange,
   placeholder,
-  togglePasswordVisibility,
-  handleKeyDown,
-  showPassword,
-  showEyeIcon = false,
-}: InputProps) => {
-  const inputShowEyeIconClassName = classNames(
-    'w-full bg-white text-base text-textColorBlack leading-5 border border-secondary rounded-md py-2 placeholder-opacity-40',
-    {
-      'pl-4 pr-9': showEyeIcon,
-      'px-4': !showEyeIcon,
-    }
-  )
+  showIcon = false,
+  children = undefined,
+}: AuthTextFieldProps) => {
+  const inputShowIconPadding = classNames({
+    'pl-4 pr-9': showIcon,
+    'px-4': !showIcon,
+  })
 
   return (
-    <div className="mb-6 w-full">
-      {label && htmlFor && (
-        <label
-          htmlFor={htmlFor}
-          className="block text-textColorBlack leading-5 font-medium text-base mb-0.5 font-inter"
-        >
-          {label}
-        </label>
-      )}
-      <div className="relative">
-        <input
-          type={type}
-          id={id}
-          value={value}
-          onChange={onChange}
-          placeholder={placeholder}
-          required
-          className={inputShowEyeIconClassName}
-        />
-        {showEyeIcon && (
-          <div
-            className="absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer"
-            onClick={togglePasswordVisibility}
-            onKeyDown={handleKeyDown}
-            tabIndex={0}
-            role="button"
-          >
-            {showPassword ? (
-              <AiFillEyeInvisible className="text-grey-400 text-2xl" />
-            ) : (
-              <AiFillEye className="text-gray-400 text-2xl" />
-            )}
-          </div>
-        )}
-      </div>
+    <div className="relative mb-6">
+      <TextField
+        type={type}
+        id={id}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        className={inputShowIconPadding}
+      />
+      {showIcon && children}
     </div>
   )
 }

--- a/src/components/AuthTextField/AuthTextField.tsx
+++ b/src/components/AuthTextField/AuthTextField.tsx
@@ -1,0 +1,85 @@
+import { FC } from 'react'
+import { AiFillEye, AiFillEyeInvisible } from 'react-icons/ai'
+import classNames from 'classnames'
+
+type RequiredProps = {
+  type: string
+  id: string
+  value: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  placeholder: string
+}
+
+type OptionalProps = {
+  label: string
+  htmlFor: string
+  togglePasswordVisibility: () => void
+  handleKeyDown: React.KeyboardEventHandler<HTMLInputElement>
+  showPassword: boolean
+  showEyeIcon: boolean
+}
+
+type InputProps = RequiredProps & Partial<OptionalProps>
+
+const AuthTextField: FC<InputProps> = ({
+  label,
+  htmlFor,
+  type,
+  id,
+  value,
+  onChange,
+  placeholder,
+  togglePasswordVisibility,
+  handleKeyDown,
+  showPassword,
+  showEyeIcon = false,
+}: InputProps) => {
+  const inputShowEyeIconClassName = classNames(
+    'w-full bg-white text-base text-textColorBlack leading-5 border border-secondary rounded-md py-2 placeholder-opacity-40',
+    {
+      'pl-4 pr-9': showEyeIcon,
+      'px-4': !showEyeIcon,
+    }
+  )
+
+  return (
+    <div className="mb-6 w-full">
+      {label && htmlFor && (
+        <label
+          htmlFor={htmlFor}
+          className="block text-textColorBlack leading-5 font-medium text-base mb-0.5 font-inter"
+        >
+          {label}
+        </label>
+      )}
+      <div className="relative">
+        <input
+          type={type}
+          id={id}
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          required
+          className={inputShowEyeIconClassName}
+        />
+        {showEyeIcon && (
+          <div
+            className="absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer"
+            onClick={togglePasswordVisibility}
+            onKeyDown={handleKeyDown}
+            tabIndex={0}
+            role="button"
+          >
+            {showPassword ? (
+              <AiFillEyeInvisible className="text-grey-400 text-2xl" />
+            ) : (
+              <AiFillEye className="text-gray-400 text-2xl" />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default AuthTextField

--- a/src/components/AuthTextField/index.ts
+++ b/src/components/AuthTextField/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AuthTextField'

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -11,6 +11,7 @@ export enum Variant {
 export enum Size {
   Default,
   Large,
+  Undefined,
 }
 
 export interface Props extends HTMLProps<HTMLButtonElement> {
@@ -46,6 +47,7 @@ const Button: FC<Props> = ({
       variant === Variant.PrimaryOutline && ['bg-white', 'text-primary', 'border', 'border-primary'],
       size === Size.Default && ['h-10'],
       size === Size.Large && ['w-72', 'h-12'],
+      size === Size.Undefined && [],
       block && ['block', 'w-full'],
       className
     )}

--- a/src/components/IconVisibility/IconVisibility.tsx
+++ b/src/components/IconVisibility/IconVisibility.tsx
@@ -1,0 +1,41 @@
+import { FC } from 'react'
+import classNames from 'classnames'
+
+export enum Variant {
+  PasswordIconVisibility,
+}
+
+export type IconVisibilityProps = {
+  visibleIcon: JSX.Element
+  invisibleIcon: JSX.Element
+  toBeVisible: boolean
+  togglePasswordVisibility: () => void
+  handleKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void
+  variant?: Variant
+}
+
+const IconVisibility: FC<IconVisibilityProps> = ({
+  visibleIcon,
+  invisibleIcon,
+  toBeVisible,
+  togglePasswordVisibility,
+  handleKeyDown,
+  variant = Variant.PasswordIconVisibility,
+}: IconVisibilityProps) => (
+  <div
+    className={classNames(
+      'cursor-pointer',
+      'absolute',
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      variant === Variant.PasswordIconVisibility && ['top-1/2', 'right-3', 'transform', '-translate-y-1/2']
+    )}
+    onClick={togglePasswordVisibility}
+    onKeyDown={handleKeyDown}
+    tabIndex={0}
+    role="button"
+  >
+    {toBeVisible ? visibleIcon : invisibleIcon}
+  </div>
+)
+
+export default IconVisibility

--- a/src/components/IconVisibility/index.ts
+++ b/src/components/IconVisibility/index.ts
@@ -1,0 +1,2 @@
+export { default } from './IconVisibility'
+export * from './IconVisibility'

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,0 +1,28 @@
+import { FC } from 'react'
+import classNames from 'classnames'
+
+export enum Variant {
+  AuthDefault,
+}
+
+type LabelProps = {
+  label: string
+  htmlFor: string
+  variant?: Variant
+}
+
+const Label: FC<LabelProps> = ({ label, htmlFor, variant = Variant.AuthDefault }) => (
+  <label
+    htmlFor={htmlFor}
+    className={classNames(
+      'block',
+      'leading-5',
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      variant === Variant.AuthDefault && ['text-textColorBlack', 'font-medium', 'mb-0.5']
+    )}
+  >
+    {label}
+  </label>
+)
+
+export default Label

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Label'

--- a/src/components/TextFiled/TextField.tsx
+++ b/src/components/TextFiled/TextField.tsx
@@ -1,0 +1,47 @@
+import { FC } from 'react'
+import classNames from 'classnames'
+
+export enum Variant {
+  AuthTextFiled,
+}
+
+export type TextFieldProps = {
+  type: string
+  id: string
+  value: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  placeholder: string
+  variant?: Variant
+  className?: string
+}
+
+const TextFiled: FC<TextFieldProps> = ({
+  type,
+  id,
+  value,
+  onChange,
+  placeholder,
+  variant = Variant.AuthTextFiled,
+  className = undefined,
+}: TextFieldProps) => (
+  <input
+    type={type}
+    id={id}
+    value={value}
+    onChange={onChange}
+    placeholder={placeholder}
+    className={classNames(
+      'w-full',
+      'text-base',
+      'border',
+      'border-secondary',
+      'rounded-md',
+      'py-2',
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      variant === Variant.AuthTextFiled && ['bg-white', 'text-textColorBlack', 'leading-5', 'placeholder-opacity-40'],
+      className
+    )}
+  />
+)
+
+export default TextFiled

--- a/src/components/TextFiled/index.ts
+++ b/src/components/TextFiled/index.ts
@@ -1,0 +1,2 @@
+export { default } from './TextField'
+export * from './TextField'

--- a/src/layouts/FlexLayout/FlexLayout.tsx
+++ b/src/layouts/FlexLayout/FlexLayout.tsx
@@ -25,7 +25,7 @@ const FlexLayout: FC<Props> = ({ children, variant }) => (
       )}
     >
       {variant === PageVariant.AuthPage && (
-        <div className="px-64 py-80 text-center">
+        <div className="px-64 py-80 text-center flex flex-col justify-center h-screen">
           <FileLogo className="w-20 h-24">
             <div className="text-xl">Form Builder</div>
           </FileLogo>

--- a/src/pages/CreateAccount/Components/Form.tsx
+++ b/src/pages/CreateAccount/Components/Form.tsx
@@ -1,17 +1,19 @@
 import { FC, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Box, Container, Typography } from '@mui/material'
+import { AiFillEye, AiFillEyeInvisible } from 'react-icons/ai'
 import { registerUser } from '@/features/auth/authSlice'
 import { useAppDispatch } from '@/app/hooks'
 import AuthButton from '@/components/AuthButton/AuthButton'
 import { Variant } from '@/components/Button'
 import AuthTextField from '@/components/AuthTextField/AuthTextField'
+import Label from '@/components/Label/Label'
+import IconVisibility from '@/components/IconVisibility/IconVisibility'
 
 const Form: FC = () => {
-  const [fullName, setFullName] = useState('')
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [showPassword, setShowPassword] = useState(false)
+  const [fullName, setFullName] = useState<string>('')
+  const [email, setEmail] = useState<string>('')
+  const [password, setPassword] = useState<string>('')
+  const [showPassword, setShowPassword] = useState<boolean>(false)
 
   const dispatch = useAppDispatch()
 
@@ -36,33 +38,12 @@ const Form: FC = () => {
   }
 
   return (
-    <Box
-      display="flex"
-      flexDirection="column"
-      justifyContent="center"
-      alignItems="center"
-      height="100%"
-      className="mx-[6.25rem]"
-    >
-      <Container>
-        <Typography
-          variant="h4"
-          sx={{
-            fontSize: '22px',
-            color: '#1E1E1E',
-            fontFamily: 'Inter',
-            fontWeight: '500',
-            lineHeight: '1.6875rem',
-            marginBottom: '25px',
-          }}
-          gutterBottom
-        >
-          Create Account
-        </Typography>
+    <div className="mx-24 flex flex-col justify-center h-screen">
+      <div>
+        <h4 className="text-2xl text-textColorBlack font-medium leading-6 mb-6">Create Account</h4>
         <form>
+          <Label label="Full Name" htmlFor="username" />
           <AuthTextField
-            label="Full Name"
-            htmlFor="username"
             type="text"
             id="username"
             value={fullName}
@@ -70,9 +51,8 @@ const Form: FC = () => {
             placeholder="Enter your username.."
           />
 
+          <Label label="Email Address" htmlFor="email" />
           <AuthTextField
-            label="Email Address"
-            htmlFor="email"
             type="email"
             id="email"
             value={email}
@@ -80,26 +60,30 @@ const Form: FC = () => {
             placeholder="Enter your email.."
           />
 
+          <Label label="Password" htmlFor="password" />
           <AuthTextField
-            label="Password"
-            htmlFor="password"
             type={showPassword ? 'text' : 'password'}
             id="password"
             value={password}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
             placeholder=""
-            togglePasswordVisibility={togglePasswordVisibility}
-            handleKeyDown={handleKeyDown}
-            showPassword={showPassword}
-            showEyeIcon
-          />
+            showIcon
+          >
+            <IconVisibility
+              visibleIcon={<AiFillEye className="text-gray-400 text-2xl" />}
+              invisibleIcon={<AiFillEyeInvisible className="text-grey-400 text-2xl" />}
+              toBeVisible={showPassword}
+              togglePasswordVisibility={togglePasswordVisibility}
+              handleKeyDown={handleKeyDown}
+            />
+          </AuthTextField>
 
           <AuthButton variant={Variant.Primary} onClick={handleRegister}>
             Sign Up
           </AuthButton>
         </form>
-      </Container>
-      <Container>
+      </div>
+      <div>
         <div className="flex items-center my-6">
           <div className="flex-grow h-0.5 bg-textColorBlack opacity-40 mr-4" />
           <span className="text-textColorBlack font-normal font-inter text-base">Already have an Account?</span>
@@ -108,8 +92,8 @@ const Form: FC = () => {
         <Link to="/auth/login">
           <AuthButton variant={Variant.PrimaryOutline}>Login</AuthButton>
         </Link>
-      </Container>
-    </Box>
+      </div>
+    </div>
   )
 }
 

--- a/src/pages/CreateAccount/Components/Form.tsx
+++ b/src/pages/CreateAccount/Components/Form.tsx
@@ -1,0 +1,116 @@
+import { FC, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Box, Container, Typography } from '@mui/material'
+import { registerUser } from '@/features/auth/authSlice'
+import { useAppDispatch } from '@/app/hooks'
+import AuthButton from '@/components/AuthButton/AuthButton'
+import { Variant } from '@/components/Button'
+import AuthTextField from '@/components/AuthTextField/AuthTextField'
+
+const Form: FC = () => {
+  const [fullName, setFullName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+
+  const dispatch = useAppDispatch()
+
+  const handleRegister = (): void => {
+    const newUser = {
+      name: fullName,
+      email,
+      password,
+    }
+
+    dispatch(registerUser(newUser))
+  }
+
+  const togglePasswordVisibility = (): void => {
+    setShowPassword(!showPassword)
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key === 'Enter') {
+      togglePasswordVisibility()
+    }
+  }
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+      height="100%"
+      className="mx-[6.25rem]"
+    >
+      <Container>
+        <Typography
+          variant="h4"
+          sx={{
+            fontSize: '22px',
+            color: '#1E1E1E',
+            fontFamily: 'Inter',
+            fontWeight: '500',
+            lineHeight: '1.6875rem',
+            marginBottom: '25px',
+          }}
+          gutterBottom
+        >
+          Create Account
+        </Typography>
+        <form>
+          <AuthTextField
+            label="Full Name"
+            htmlFor="username"
+            type="text"
+            id="username"
+            value={fullName}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setFullName(e.target.value)}
+            placeholder="Enter your username.."
+          />
+
+          <AuthTextField
+            label="Email Address"
+            htmlFor="email"
+            type="email"
+            id="email"
+            value={email}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+            placeholder="Enter your email.."
+          />
+
+          <AuthTextField
+            label="Password"
+            htmlFor="password"
+            type={showPassword ? 'text' : 'password'}
+            id="password"
+            value={password}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
+            placeholder=""
+            togglePasswordVisibility={togglePasswordVisibility}
+            handleKeyDown={handleKeyDown}
+            showPassword={showPassword}
+            showEyeIcon
+          />
+
+          <AuthButton variant={Variant.Primary} onClick={handleRegister}>
+            Sign Up
+          </AuthButton>
+        </form>
+      </Container>
+      <Container>
+        <div className="flex items-center my-6">
+          <div className="flex-grow h-0.5 bg-textColorBlack opacity-40 mr-4" />
+          <span className="text-textColorBlack font-normal font-inter text-base">Already have an Account?</span>
+          <div className="flex-grow h-0.5 bg-textColorBlack opacity-40 ml-4" />
+        </div>
+        <Link to="/auth/login">
+          <AuthButton variant={Variant.PrimaryOutline}>Login</AuthButton>
+        </Link>
+      </Container>
+    </Box>
+  )
+}
+
+export default Form

--- a/src/pages/CreateAccount/Components/index.ts
+++ b/src/pages/CreateAccount/Components/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Form'

--- a/src/pages/CreateAccount/CreateAccount.tsx
+++ b/src/pages/CreateAccount/CreateAccount.tsx
@@ -1,5 +1,13 @@
 import { FC } from 'react'
+import AuthLayout from '@/layouts/AuthLayout/AuthLayout'
+import Form from './Components'
 
-const CreateAccount: FC = () => <div>this is create account page</div>
+const CreateAccount: FC = () => (
+  <div>
+    <AuthLayout>
+      <Form />
+    </AuthLayout>
+  </div>
+)
 
 export default CreateAccount


### PR DESCRIPTION
Solve Conflict on branch ```CB-6-Create-Account-page-figma-1-c-create-account-UI-Layout-Part-Two```
- [x] Add ```AuthButton``` and ```AuthTextFiled``` folders under ```components``` folder
- [x] Add ```Undefined``` enum in ```Button``` for adjusting ```size``` prop
- [x] Update ```CreateAccount``` page information and create ```Form``` component under ```CreateAccount/Components``` folder.